### PR TITLE
Fixed bug with CMB2 select2 instances

### DIFF
--- a/assets/src/sass/plugin-admin.scss
+++ b/assets/src/sass/plugin-admin.scss
@@ -149,5 +149,10 @@
  * The z-index was too small to show in the pop-up.
  */
 .select2-container {
-	z-index: 1000100 !important;
+	z-index: 160000 !important;
+}
+
+// Prevent z-index modifications to CMB2 select2 instances.
+.cmb-td .select2-container {
+	z-index: inherit !important;	
 }


### PR DESCRIPTION
The `.select2-container` element of CMB2 select2 instances were found to be appearing above the WP media management window due to the extremely high z-index value. This fix tones down the `.select2-container` z-index value, while also forcing a z-index inherit on any `.select2-container` element nested inside a `.cmb-td` column. This is going to need an assets re-build.